### PR TITLE
Fix search (multiple releases) and Add some shows

### DIFF
--- a/addic7ed_dict.txt
+++ b/addic7ed_dict.txt
@@ -2,4 +2,6 @@
 'Cosmos A Space Time Odyssey': 'Cosmos: A Space-Time Odyssey',
 'Greys Anatomy': 'Grey\'s Anatomy',
 'Shameless': 'Shameless (US)',
-'The Americans (2013)': 'The Americans'}
+'The Americans (2013)': 'The Americans',
+'Once Upon a Time (2011)': 'Once Upon a Time',
+'Castle (2009)': 'Castle'}

--- a/service.py
+++ b/service.py
@@ -87,10 +87,10 @@ def query(searchurl, langs, file_original_path, filename_string):
 
   file_name = str(os.path.basename(file_original_path)).split("-")[-1].lower()
 
-  for subs in soup("td", {"class":"NewsTitle", "colspan" : "3"}):
+  for langs_html in soup("td", {"class" : "language"}):
 
     try:
-      langs_html = subs.findNext("td", {"class" : "language"})
+      subs = langs_html.findPrevious("td", {"class":"NewsTitle", "colspan" : "3"})
       fullLanguage = str(langs_html).split('class="language">')[1].split('<a')[0].replace("\n","")
       subteams = self_release_pattern.match(str(subs.contents[1])).groups()[0]
 


### PR DESCRIPTION
These two commits were already present in cflannagan's fork but I think they were not reported here.

The first one corrects the search function that didn't show multiple versions (and so multiple languages) for a given release.
The second simply adds 2 shows that are not correctly found in Addic7ed database.

Additional information can be found here: https://github.com/cflannagan/service.subtitles.addic7ed/pull/16
