### PR TITLE
Fix a unicode bug

### DIFF
--- a/service.py
+++ b/service.py
@@ -85,7 +85,8 @@ def query(searchurl, langs, file_original_path, filename_string):
   content = content.replace("The safer, easier way", "The safer, easier way \" />")
   soup = BeautifulSoup(content)
 
-  file_name = str(os.path.basename(file_original_path)).split("-")[-1].lower()
+  file_original_path_clean = normalizeString(file_original_path.encode('utf-8'))
+  file_name = str(os.path.basename(file_original_path_clean)).split("-")[-1].lower()
 
   for langs_html in soup("td", {"class" : "language"}):
 


### PR DESCRIPTION
In query, file_name doesn't need to be an accurate string, we only want to know if WEB-DL is present.
Normalizing doesn't hurt and fix a unicode encode/decode problem.